### PR TITLE
Minio patch

### DIFF
--- a/manifests/spinnaker.yaml
+++ b/manifests/spinnaker.yaml
@@ -177,13 +177,13 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - mkdir -p /storage/spinnaker && /usr/bin/minio server /storage
+        - mkdir -p /storage/spinnaker && /opt/bin/minio server /storage
         env:
         - name: MINIO_ACCESS_KEY
           value: minio
         - name: MINIO_SECRET_KEY
           value: minio-secret
-        image: minio/minio
+        image: minio/minio:RELEASE.2021-09-15T04-54-25Z
         name: minio
         ports:
         - containerPort: 9000

--- a/templates/spinnaker-entrypoint-new-vpc.template.yml
+++ b/templates/spinnaker-entrypoint-new-vpc.template.yml
@@ -104,8 +104,6 @@ Metadata:
         default: Database administrator password
       ProvisionBastionHost:
         default: Provision bastion host
-      EnableTCPForwarding:
-        default: Enable TCP forwarding
       PrivateSubnet1CIDR:
         default: Private subnet 1 CIDR
       PrivateSubnet2CIDR:


### PR DESCRIPTION
*Issue #, if available:*
minio/minio image changed the binary path from /usr/bin/minio to /opt/bin/minio

*Description of changes:*
Adjust container cmd to match the image changes.
Add a TAG to ensure we always get a know working container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
